### PR TITLE
Add v1 rule selection and fix spec inconsistencies

### DIFF
--- a/spec/EXAMPLES.md
+++ b/spec/EXAMPLES.md
@@ -21,7 +21,7 @@ These examples define expected behavior for analysis, fixes, formatting, inline 
 
 ### Expected issues (summary)
 - format/normalize-spaces (info)
-- format/property-per-line (warning)
+- format/multiple-declarations-per-line (warning)
 - format/indent-2-spaces (warning)
 - tokens/shorten-hex-colors (warning)
 
@@ -36,7 +36,7 @@ These examples define expected behavior for analysis, fixes, formatting, inline 
 ### Expected output (with comments)
 ```css
 .button {
-  display: flex; /* cssreview: format/property-per-line: split declarations */
+  display: flex; /* cssreview: format/multiple-declarations-per-line: split declarations */
   color: #fff; /* cssreview: tokens/shorten-hex-colors: was #ffffff */
 }
 ```
@@ -199,7 +199,7 @@ These examples define expected behavior for analysis, fixes, formatting, inline 
 ```
 
 ### Expected issues (summary)
-- modern/suggest-place-properties (info, prompt)
+- modern/suggest-place-shorthand (info, prompt)
 
 ### Expected “LLM prompt” output (concept)
 ```text


### PR DESCRIPTION
- Add v1 Rule Selection section to RULEBOOK_INDEX.md with 3 tiers:
  - Tier 1: 15 core rules (must have for v1.0)
  - Tier 2: 5 valuable additions (included in v1.0)
  - Tier 3: Deferred rules for v1.1+

- Add missing rules to RULEBOOK_INDEX.md:
  - consolidate/deduplicate-last-wins (safe fix)
  - modern/suggest-place-shorthand (prompt)

- Fix EXAMPLES.md inconsistencies:
  - Rename format/property-per-line → format/multiple-declarations-per-line
  - Rename modern/suggest-place-properties → modern/suggest-place-shorthand

https://claude.ai/code/session_016FPPJe8oJbsjJsBRGdagz5