### PR TITLE
Fix PreToolUse hook path: replace unresolved $CLAUDE_PROJECT_DIR with absolute path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-file-size.sh"
+            "command": "/home/user/CSS-promptify/.claude/hooks/check-file-size.sh"
           }
         ]
       }


### PR DESCRIPTION
The CLAUDE_PROJECT_DIR environment variable was not available in the
hook execution context, causing the check-file-size.sh hook to silently
fail. Use the absolute project path instead.

https://claude.ai/code/session_01UkyPpy3jP11unCbNwEPxnr